### PR TITLE
ci: set timeout for jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
 jobs:
   Build:
+    timeout-minutes: 20
     runs-on: 'ubuntu-latest'
 
     strategy:

--- a/.github/workflows/NIGHTLY.yml
+++ b/.github/workflows/NIGHTLY.yml
@@ -4,6 +4,7 @@ on:
     - cron: '0 9 * * *'
 jobs:
   Build:
+    timeout-minutes: 20
     runs-on: 'ubuntu-latest'
     env:
       VERSION: nightly


### PR DESCRIPTION
### Proposed Changes

This is to override default 6 hours timeout which has already happened in this repo: https://github.com/bpmn-io/camunda-modeler-a11y-test/actions/runs/9611616207
The timeout is set to 20 minutes.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
