### PR TITLE
ci: increase timeout to 20s

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "pull:modeler": "node lib/helper/setupModeler",
     "test": "run-s test:*",
-    "test:unit": "mocha --timeout 5000 --recursive test/spec",
-    "test:a11y": "mocha --timeout 5000 --recursive test/a11y",
+    "test:unit": "mocha --timeout 20000 --recursive test/spec",
+    "test:a11y": "mocha --timeout 20000 --recursive test/a11y",
     "lint": "eslint .",
     "pull": "run-p pull:*",
     "start": "run-s test:a11y",

--- a/test/spec/createModeler.spec.js
+++ b/test/spec/createModeler.spec.js
@@ -10,8 +10,6 @@ const WORKSPACE_DIR = 'lib/tmp/workspace';
 
 describe('lib/helper/createModeler - initialization', function() {
 
-  this.timeout(5000);
-
   let modeler;
 
   afterEach(async () => {
@@ -82,9 +80,6 @@ describe('lib/helper/createModeler - initialization', function() {
 
 
 describe('lib/helper/createModeler - teardown', function() {
-
-  this.timeout(5000);
-
 
   it('should close a Modeler instance', async () => {
 


### PR DESCRIPTION
### Proposed Changes

This PR increases the timeout for test cases to 20s so that the jobs don't time out on slow GH Actions runners.
<!--
Add relevant context (issue fixed or related to),
a capture of the UI changes (if any) as well as
steps to try out your changes.
-->

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
